### PR TITLE
fix bug when text value of tag is "0"

### DIFF
--- a/src/Transform.php
+++ b/src/Transform.php
@@ -41,7 +41,7 @@ class Transform
             
             while ($xmlReader->read()) {
                 if ($xmlReader->nodeType == XMLReader::TEXT) {
-                    if (!empty(trim($xmlReader->value))) {
+                    if (trim($xmlReader->value) !== '') {
                         $xmlWriter->text($xmlReader->value);
                     }
                     continue;

--- a/tests/TransformTest.php
+++ b/tests/TransformTest.php
@@ -25,12 +25,27 @@ class TransformTest extends TestCase
                         qwe:attF="fff"
                     />
                 </qwe:elementTwo>
+                <qwe:elementFour>0</qwe:elementFour>
+                <qwe:elementFive/>
+                <qwe:elementSix>   </qwe:elementSix>
             </elementOne>';
-        
-        $expectedXml = '<ns1:elementOne xmlns:ns1="http://test/1"><ns2:elementTwo xmlns:ns2="http://test/2"><ns3:elementThree xmlns:ns3="http://test/3" xmlns:ns4="http://test/0" xmlns:ns5="http://test/a" ns4:attC="ccc" ns2:attF="fff" ns3:attD="ddd" ns3:attE="eee" ns5:attZ="zzz" attA="aaa" attB="bbb"></ns3:elementThree></ns2:elementTwo></ns1:elementOne>';
-        
+
+        $expectedXml = '<ns1:elementOne xmlns:ns1="http://test/1">'
+            . '<ns2:elementTwo xmlns:ns2="http://test/2">'
+            . '<ns3:elementThree xmlns:ns3="http://test/3" xmlns:ns4="http://test/0" xmlns:ns5="http://test/a" ns4:attC="ccc" ns2:attF="fff" ns3:attD="ddd" ns3:attE="eee" ns5:attZ="zzz" attA="aaa" attB="bbb"></ns3:elementThree>'
+            . '</ns2:elementTwo>'
+            . '<ns2:elementFour>0</ns2:elementFour>'
+            . '<ns2:elementFive></ns2:elementFive>'
+            . '<ns2:elementSix></ns2:elementSix>'
+            . '</ns1:elementOne>';
+
         $transform = new Transform();
-        
-        $this->assertXmlStringEqualsXmlString($expectedXml, $transform->process($srcXml));
+
+        /*
+         * We shouldn't use assertXmlStringEqualsXmlString method for tests because it do not see differences
+         * between empty paired and a self-closing tags according to the specs. 
+         * But it is strictly necessary for us because of SMEV rule №3
+         */
+        $this->assertEquals($expectedXml, $transform->process($srcXml));
     }
 }


### PR DESCRIPTION
tags like `<price>0</price>` should be written to transformed XML